### PR TITLE
chore(fonts): split font loading into fonts.js

### DIFF
--- a/src/fonts/fonts.js
+++ b/src/fonts/fonts.js
@@ -1,0 +1,48 @@
+import { Font } from 'react-pdf';
+import RobotoLight from 'fonts/Roboto-Light.ttf';
+import RobotoItalicLight from 'fonts/Roboto-LightItalic.ttf';
+import Roboto from 'fonts/Roboto-Regular.ttf';
+import RobotoItalic from 'fonts/Roboto-Italic.ttf';
+import RobotoBold from 'fonts/Roboto-Bold.ttf';
+import RobotoItalicBold from 'fonts/Roboto-BoldItalic.ttf';
+import Merriweather from 'fonts/Merriweather-Regular.ttf';
+import MerriweatherLight from 'fonts/Merriweather-Light.ttf';
+import MerriweatherBold from 'fonts/Merriweather-Bold.ttf';
+import MerriweatherBoldItalic from 'fonts/Merriweather-BoldItalic.ttf';
+import MerriweatherItalic from 'fonts/Merriweather-Italic.ttf';
+import MerriweatherLightItalic from 'fonts/Merriweather-LightItalic.ttf';
+
+Font.register({
+  family: 'Roboto',
+  fonts: [
+    { src: Roboto },
+    { src: RobotoLight },
+    { src: RobotoBold, fontWeight: 700 },
+  ],
+});
+
+Font.register({
+  family: 'RobotoItalic',
+  fonts: [
+    { src: RobotoItalic },
+    { src: RobotoItalicLight },
+    { src: RobotoItalicBold, fontWeight: 700 },
+  ],
+});
+
+Font.register({
+  family: 'Merriweather',
+  fonts: [
+    { src: Merriweather },
+    { src: MerriweatherLight },
+    { src: MerriweatherBold, fontWeight: 700 },
+  ],
+});
+Font.register({
+  family: 'MerriweatherItalic',
+  fonts: [
+    { src: MerriweatherItalic },
+    { src: MerriweatherLightItalic },
+    { src: MerriweatherBoldItalic, fontWeight: 700 },
+  ],
+});

--- a/src/index.js
+++ b/src/index.js
@@ -4,55 +4,7 @@ import { HashRouter } from 'react-router-dom';
 import './scss/index.scss';
 import App from './components/app/App';
 import * as serviceWorker from './serviceWorker';
-
-import { Font } from 'react-pdf';
-import RobotoLight from 'fonts/Roboto-Light.ttf';
-import RobotoItalicLight from 'fonts/Roboto-LightItalic.ttf';
-import Roboto from 'fonts/Roboto-Regular.ttf';
-import RobotoItalic from 'fonts/Roboto-Italic.ttf';
-import RobotoBold from 'fonts/Roboto-Bold.ttf';
-import RobotoItalicBold from 'fonts/Roboto-BoldItalic.ttf';
-import Merriweather from 'fonts/Merriweather-Regular.ttf';
-import MerriweatherLight from 'fonts/Merriweather-Light.ttf';
-import MerriweatherBold from 'fonts/Merriweather-Bold.ttf';
-import MerriweatherBoldItalic from 'fonts/Merriweather-BoldItalic.ttf';
-import MerriweatherItalic from 'fonts/Merriweather-Italic.ttf';
-import MerriweatherLightItalic from 'fonts/Merriweather-LightItalic.ttf';
-
-Font.register({
-  family: 'Roboto',
-  fonts: [
-    { src: Roboto },
-    { src: RobotoLight },
-    { src: RobotoBold, fontWeight: 700 },
-  ],
-});
-
-Font.register({
-  family: 'RobotoItalic',
-  fonts: [
-    { src: RobotoItalic },
-    { src: RobotoItalicLight },
-    { src: RobotoItalicBold, fontWeight: 700 },
-  ],
-});
-
-Font.register({
-  family: 'Merriweather',
-  fonts: [
-    { src: Merriweather },
-    { src: MerriweatherLight },
-    { src: MerriweatherBold, fontWeight: 700 },
-  ],
-});
-Font.register({
-  family: 'MerriweatherItalic',
-  fonts: [
-    { src: MerriweatherItalic },
-    { src: MerriweatherLightItalic },
-    { src: MerriweatherBoldItalic, fontWeight: 700 },
-  ],
-});
+import 'fonts/fonts.js';
 
 ReactDOM.render(
   <HashRouter>


### PR DESCRIPTION
#### Summary

- Work Type: Chore <!-- Feature | Bugfix | Chore | Refactor -->

#### What I did

- Moved logic related to loading fonts into its own file
-
-

#### Before/After Preview

- Before:
<!-- Insert relevant screenshot here -->
- After:
<!-- Insert relevant screenshot here -->

#### Checklist

- [x] Branch is in format `TYPE/scope/description`
- [x] PR title is in format `TYPE(scope): description`
- [x] Commits are in semantic format
- [x] Has Summary
- [x] Has Labels
