### PR TITLE
chore(webpack): split prod/dev configs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 	publish = "dist"
-	command = "npm run build"
+	command = "npm run build:prod"
 
 [[redirects]]
   from = "/*"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "stream-browserify": "^3.0.0"
   },
   "scripts": {
-    "start": "npx webpack-dev-server",
+    "start": "npx webpack-dev-server --config ./webpack.dev.config.js",
     "build:dev": "webpack --config ./webpack.dev.config.js",
     "build:prod": "webpack --config ./webpack.prod.config.js",
     "test": "react-scripts test",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "scripts": {
     "start": "npx webpack-dev-server",
-    "build": "webpack -p",
+    "build:dev": "webpack --config ./webpack.dev.config.js",
+    "build:prod": "webpack --config ./webpack.prod.config.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "prettier-format": "prettier --config .prettierrc 'src/**/*.{js,scss}' --write",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,14 +4,12 @@ const CopyPlugin = require('copy-webpack-plugin');
 const webpack = require('webpack');
 
 module.exports = {
-  mode: 'development',
   entry: './src/index.js',
   output: {
     path: path.resolve(__dirname, 'dist'),
     filename: 'bundle.js',
     publicPath: '/',
   },
-  devtool: 'eval-source-map',
   module: {
     rules: [
       {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,90 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
 const webpack = require('webpack');
 
+const rules = [
+  {
+    test: /\.js$/,
+    loader: 'babel-loader',
+    exclude: /node_modules/,
+  },
+  {
+    test: /\.s[ac]ss$/i,
+    use: ['style-loader', 'css-loader', 'sass-loader'],
+  },
+  {
+    test: /\.js$/,
+    enforce: 'pre',
+    use: ['source-map-loader'],
+  },
+  {
+    test: /\.(webm|webp|mp4|png)$/,
+    loader: 'file-loader',
+  },
+  {
+    test: /\.(woff(2)?|ttf|eot|svg)(\?v=\d+\.\d+\.\d+)?$/,
+    use: [
+      {
+        loader: 'file-loader',
+        options: {
+          name: '[name].[ext]',
+          outputPath: 'fonts/',
+        },
+      },
+    ],
+  },
+];
+
+const plugins = [
+  new HtmlWebpackPlugin({
+    template: './public/index.html',
+    favicon: './public/favicon.ico',
+  }),
+  new CopyPlugin({
+    patterns: [
+      {
+        from: 'public/manifest.json',
+        to: 'assets/manifest.json',
+        toType: 'file',
+      },
+      {
+        from: 'public/robots.txt',
+        to: 'assets/robots.txt',
+        toType: 'file',
+      },
+      {
+        from: 'public/logo192.png',
+        to: 'assets/logo192.png',
+        toType: 'file',
+      },
+      {
+        from: 'public/logo512.png',
+        to: 'assets/logo512.png',
+        toType: 'file',
+      },
+    ],
+  }),
+  new webpack.ProvidePlugin({
+    Buffer: ['buffer', 'Buffer'],
+  }),
+  new webpack.ProvidePlugin({
+    process: 'process/browser',
+  }),
+];
+
+const alias = {
+  'code-mirror-lint': path.resolve(
+    __dirname,
+    'src/custom-packages/code-mirror-lint.js',
+  ),
+  'json-lint': path.resolve(__dirname, 'src/custom-packages/json-lint.js'),
+  'react-pdf': path.resolve(__dirname, 'node_modules/@react-pdf/renderer'),
+  'src/components': path.resolve(__dirname, 'src/components'),
+  'src/customizers': path.resolve(__dirname, 'src/components/customizers'),
+  'src/fonts': path.resolve(__dirname, 'src/fonts/fonts.js'),
+  'src/pages': path.resolve(__dirname, 'src/components/pages'),
+  'src/templates': path.resolve(__dirname, 'src/components/templates'),
+};
+
 module.exports = {
   entry: './src/index.js',
   output: {
@@ -11,98 +95,20 @@ module.exports = {
     publicPath: '/',
   },
   module: {
-    rules: [
-      {
-        test: /\.js$/,
-        loader: 'babel-loader',
-        exclude: /node_modules/,
-      },
-      {
-        test: /\.s[ac]ss$/i,
-        use: ['style-loader', 'css-loader', 'sass-loader'],
-      },
-      {
-        test: /\.js$/,
-        enforce: 'pre',
-        use: ['source-map-loader'],
-      },
-      {
-        test: /\.(webm|webp|mp4|png)$/,
-        loader: 'file-loader',
-      },
-      {
-        test: /\.(woff(2)?|ttf|eot|svg)(\?v=\d+\.\d+\.\d+)?$/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              name: '[name].[ext]',
-              outputPath: 'fonts/',
-            },
-          },
-        ],
-      },
-    ],
+    rules,
   },
+  plugins,
   devServer: {
     port: 3000,
     open: true,
     hot: true,
   },
   resolve: {
-    alias: {
-      'code-mirror-lint': path.resolve(
-        __dirname,
-        'src/custom-packages/code-mirror-lint.js',
-      ),
-      'json-lint': path.resolve(__dirname, 'src/custom-packages/json-lint.js'),
-      'react-pdf': path.resolve(__dirname, 'node_modules/@react-pdf/renderer'),
-      'src/components': path.resolve(__dirname, 'src/components'),
-      'src/customizers': path.resolve(__dirname, 'src/components/customizers'),
-      'src/fonts': path.resolve(__dirname, 'src/fonts/fonts.js'),
-      'src/pages': path.resolve(__dirname, 'src/components/pages'),
-      'src/templates': path.resolve(__dirname, 'src/components/templates'),
-    },
+    alias,
     fallback: {
       fs: require.resolve('fs'),
       stream: require.resolve('stream-browserify'),
       zlib: require.resolve('browserify-zlib'),
     },
   },
-  plugins: [
-    new HtmlWebpackPlugin({
-      template: './public/index.html',
-      favicon: './public/favicon.ico',
-    }),
-    new CopyPlugin({
-      patterns: [
-        {
-          from: 'public/manifest.json',
-          to: 'assets/manifest.json',
-          toType: 'file',
-        },
-        {
-          from: 'public/robots.txt',
-          to: 'assets/robots.txt',
-          toType: 'file',
-        },
-        {
-          from: 'public/logo192.png',
-          to: 'assets/logo192.png',
-          toType: 'file',
-        },
-        {
-          from: 'public/logo512.png',
-          to: 'assets/logo512.png',
-          toType: 'file',
-        },
-      ],
-    }),
-    new webpack.ProvidePlugin({
-      Buffer: ['buffer', 'Buffer'],
-    }),
-    new webpack.ProvidePlugin({
-      process: 'process/browser',
-    }),
-  ],
 };

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -1,0 +1,6 @@
+const webpackConfig = require('./webpack.config');
+
+webpackConfig.mode = 'development';
+webpackConfig.devtool = 'eval-source-map';
+
+module.exports = webpackConfig;

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -1,0 +1,5 @@
+const webpackConfig = require('./webpack.config');
+
+webpackConfig.mode = 'production';
+
+module.exports = webpackConfig;


### PR DESCRIPTION
#### Summary

- Work Type: Chore <!-- Feature | Fix | Chore | Refactor -->

#### What I did

- Split prod and dev
- Reduces Prod startup time. Before takes 20 seconds to load. Now ~4

#### Before / After

bundle at 12 MB
<img width="500" alt="Screen Shot 2020-12-12 at 1 01 17 PM" src="https://user-images.githubusercontent.com/20917792/101991352-28049e00-3c7a-11eb-9322-19b825538d59.png">

bundle at 2 MB
<img width="500" alt="Screen Shot 2020-12-12 at 1 02 28 PM" src="https://user-images.githubusercontent.com/20917792/101991378-51bdc500-3c7a-11eb-87a3-66a712dc1433.png">



#### Checklist

- [x] Branch is in format `TYPE/scope/description`
- [x] PR title is in format `TYPE(scope): description`
- [x] Commits are in semantic format
- [x] Has Summary
- [x] Has Labels
