### PR TITLE
fix(pages): fix home page triplets section

### DIFF
--- a/src/components/pages/HomePage.js
+++ b/src/components/pages/HomePage.js
@@ -38,8 +38,7 @@ export const HomePage = () => {
             <GrMultiple className="triplet-icon" />
             <h3>Choose your template</h3>
             <p className="triplet-text">
-              Pick from our library of templates to find the one that best fits
-              you.
+              Pick from our templates to find the one that best fits you.
             </p>
           </article>
           <article className="triplet">

--- a/src/scss/Pages/HomePage.scss
+++ b/src/scss/Pages/HomePage.scss
@@ -110,7 +110,6 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
-  justify-content: space-around;
   z-index: 2;
 }
 
@@ -120,7 +119,6 @@
   flex-direction: column;
   display: flex;
   height: 30vh;
-  margin-left: 50px;
 
   & > p {
     font-size: 25px;
@@ -134,7 +132,6 @@
   display: flex;
   flex-direction: row;
   justify-content: space-around;
-  height: 70vh;
 }
 
 .triplet {
@@ -142,14 +139,17 @@
   background-color: $base2;
   border-radius: 20px;
   color: $base02;
-  display: flex;
+  display: grid;
+  grid-template-rows: 1fr 1fr 1fr;
   flex-direction: column;
   font-size: 25px;
   justify-content: flex-start;
-  height: 40vh;
   position: relative;
-  width: 20vw;
   padding: 5px;
+
+  & > svg {
+    margin: auto;
+  }
 }
 
 .triplet-icon {


### PR DESCRIPTION
#### Summary

- Work Type: fix <!-- Feature | Fix | Chore | Refactor -->

#### What I did

- Images and baseline of text is now aligned. Fixed issue where height of SVG was 0 or very small

#### Before/After


Before: 
<img width="965" alt="Screen Shot 2021-01-04 at 9 42 01 PM" src="https://user-images.githubusercontent.com/20917792/103600574-c5e43500-4ed5-11eb-84c5-0347b60f1290.png">

After:
<img width="1493" alt="Screen Shot 2021-01-04 at 9 42 10 PM" src="https://user-images.githubusercontent.com/20917792/103600578-c8df2580-4ed5-11eb-8ae4-3cdeb8319a95.png">




#### Checklist

- [x] Branch is in format `TYPE/scope/description`
- [x] PR title is in format `TYPE(scope): description`
- [x] Commits are in semantic format
- [x] Has Summary
- [x] Has Labels
