### PR TITLE
chore(github): fix typo for templates scope

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -34,5 +34,5 @@ scopes:
   - prettier
   - readme
   - roadmap
-  - templatees
+  - templates
   - webpack


### PR DESCRIPTION
#### Summary

- Work Type: <!-- Feature | Fix | Chore | Refactor -->

#### What I did

-
-
-

#### Checklist

- [ ] Branch is in format `TYPE/scope/description`
- [ ] PR title is in format `TYPE(scope): description`
- [ ] Commits are in semantic format
- [ ] Has Summary
- [ ] Has Labels
