### PR TITLE
fix(home-page): fix text overflowing into next section

### DIFF
--- a/src/scss/Pages/HomePage.scss
+++ b/src/scss/Pages/HomePage.scss
@@ -140,12 +140,13 @@
   border-radius: 20px;
   color: $base02;
   display: grid;
-  grid-template-rows: 1fr 1fr 1fr;
+  grid-template-rows: 1fr auto auto;
   flex-direction: column;
   font-size: 25px;
   justify-content: flex-start;
   position: relative;
   padding: 5px;
+  margin: 5px;
 
   & > svg {
     margin: auto;

--- a/src/scss/Pages/HomePage.scss
+++ b/src/scss/Pages/HomePage.scss
@@ -108,8 +108,8 @@
   background-color: $base2;
   color: $base02;
   display: flex;
+  padding: 60px 0 60px 0;
   flex-direction: column;
-  height: 100vh;
   z-index: 2;
 }
 


### PR DESCRIPTION
#### Summary

- Work Type: Fix 

#### What I did

- Fix triple column text from overflowing into the next section 
- Adjust CSS
-

#### Screenshots

Before: 
<img width="923" alt="Screen Shot 2021-01-27 at 9 31 28 PM" src="https://user-images.githubusercontent.com/44790175/106081592-25092400-60e7-11eb-824e-7fc5a70fa7d8.png">

After:
<img width="889" alt="Screen Shot 2021-01-27 at 9 31 57 PM" src="https://user-images.githubusercontent.com/44790175/106081624-2e928c00-60e7-11eb-87de-bd3a9f0e4030.png">

#### Checklist

- [x] Branch is in format `TYPE/scope/description`
- [x] PR title is in format `TYPE(scope): description`
- [x] Commits are in semantic format
- [x] Has Summary
- [x] Has Labels
