### PR TITLE
feat(home-page): replace placeholder video with youtube video

### DIFF
--- a/src/components/pages/HomePage.js
+++ b/src/components/pages/HomePage.js
@@ -73,8 +73,17 @@ export const HomePage = () => {
         </div>
       </section>
       <section className="youtube-how-to-section">
-        <h2 className="section-title">Video Demo Section</h2>
-        <div className="video-demo">Video demo coming soon.</div>
+        <h2 className="section-title">Video Demo</h2>
+        <div className="video-demo">
+          <iframe
+            width="885"
+            height="500"
+            src="https://www.youtube.com/embed/_tvsOnnn2g8"
+            frameBorder="0"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+          ></iframe>
+        </div>
       </section>
       <Footer />
     </main>

--- a/src/scss/Pages/HomePage.scss
+++ b/src/scss/Pages/HomePage.scss
@@ -196,18 +196,15 @@
 
 .video-demo {
   align-items: center;
-  background-color: $red;
   color: $white;
   font-size: 50px;
   display: flex;
-  height: 50vh;
   justify-content: center;
-  width: 50vw;
-  margin: 200px auto;
+  margin: 50px auto;
 }
 
 .youtube-how-to-section {
   background-color: $base3;
-  color: $red;
+  color: $base02;
   text-align: center;
 }


### PR DESCRIPTION
#### Summary
*Enumerate changes of what this PR does*

-  Adds in video demo to home page

#### Screenshots
*Provide before/after screenshots if applicable*

Before
<img width="500" alt="Screen Shot 2021-02-03 at 8 54 22 PM" src="https://user-images.githubusercontent.com/44790175/106833740-162fed80-6662-11eb-97b4-7573adf6ff31.png">

After
<img width="500" alt="Screen Shot 2021-02-03 at 8 54 12 PM" src="https://user-images.githubusercontent.com/44790175/106833766-21831900-6662-11eb-9c73-20fd65d62da3.png">



#### Checklist

- [x] Branch should be in format `TYPE/scope/description`
- [x] PR title is in format `TYPE(scope): description`
  - Expected TYPES, scopes are listed [here](https://github.com/starter-code/res-gen/blob/master/.github/semantic.yml)
- [x] Commits are in semantic format
