### PR TITLE
feat(editor): add button to export json file

### DIFF
--- a/src/components/editor/Editor.js
+++ b/src/components/editor/Editor.js
@@ -19,11 +19,33 @@ export const Editor = ({ setData, defaultData, type }) => {
     setData(defaultData);
   }, [type, editorRef, defaultData]);
 
+  const stringData = JSON.stringify(defaultData, null, 4);
+
+  const handleExportJson = () => {
+    const filename = 'res-gen.json';
+
+    let element = document.createElement('a');
+    element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(stringData));
+    element.setAttribute('download', filename);
+
+    element.style.display = 'none';
+    document.body.appendChild(element);
+
+    element.click();
+
+    document.body.removeChild(element);
+  };
+
   return (
     <div>
-      <button className="update-pdf-button" onClick={onHandleClick}>
-        Apply Changes
-      </button>
+      <div>
+        <button className="update-pdf-button" onClick={onHandleClick}>
+          Apply Changes
+        </button>
+        <button className="export-json-button" onClick={handleExportJson}>
+          Export File
+        </button>
+      </div>
       <form>
         <textarea
           onChange={onHandleChange}

--- a/src/scss/Pages/EditorPage.scss
+++ b/src/scss/Pages/EditorPage.scss
@@ -92,6 +92,28 @@
   flex-direction: column;
 }
 
+.export-json-button {
+  border-radius: 40px;
+  border-style: none;
+  bottom: 10px;
+  cursor: pointer;
+  font-weight: 700;
+  outline: none;
+  padding: 10px 20px;
+  position: absolute;
+  right: 10px;
+  transition: background-color 0.25s;
+  z-index: 100;
+
+  &:hover {
+    transform: scale(1.1);
+  }
+
+  &:active {
+    background-color: $base01;
+  }
+}
+
 .update-pdf-button {
   border-radius: 40px;
   border-style: none;


### PR DESCRIPTION
Resolves: https://github.com/starter-code/res-gen/issues/76

#### Summary
*Enumerate changes of what this PR does*

- Adds a button to export JSON file so users can come back to resume later.
-
-

#### Screenshots
*Provide before/after screenshots if applicable*
<img width="1439" alt="Screen Shot 2021-10-17 at 2 11 04 PM" src="https://user-images.githubusercontent.com/44790175/137639604-04584a13-befd-45ff-8aeb-0ac959d33224.png">


#### Checklist

- [x] Branch should be in format `TYPE/scope/description`
- [x] PR title is in format `TYPE(scope): description`
  - Expected TYPES, scopes are listed [here](https://github.com/starter-code/res-gen/blob/master/.github/semantic.yml)
- [x] Commits are in semantic format
